### PR TITLE
set sqlite PRAGMAs to improve performance

### DIFF
--- a/src/report/sqlite/report_builder.rs
+++ b/src/report/sqlite/report_builder.rs
@@ -55,6 +55,14 @@ pub struct SqliteReportBuilder {
 impl SqliteReportBuilder {
     fn new_with_rng(filename: PathBuf, rng: StdRng) -> Result<SqliteReportBuilder> {
         let conn = open_database(&filename)?;
+        // Trust the operating system to perform writes successfully
+        conn.pragma_update(None, "synchronous", "OFF")?;
+
+        // Don't keep a transaction journal; if we need to roll back, it's unrecoverable
+        conn.pragma_update(None, "journal_mode", "OFF")?;
+
+        // Allow SQLite to hold more database disk pages in memory
+        conn.pragma_update(None, "cache_size", "-200000")?;
         Ok(SqliteReportBuilder {
             filename,
             conn,


### PR DESCRIPTION
quick changes to SQLite pragmas to improve bulk insert performance:
- `journal_mode=OFF`: no transaction journal, we can't roll back (in SQLite). we can still "rollback" by just not persisting/exporting the SQLite database after failed processing
- `cache_size=-200000`: set the SQLite page cache size to ~200MB
- `synchronous=OFF`: trust the filesystem to perform reads reliably

`journal_mode` and `cache_size` together improve bulk insert speed for my 110mb test report by about a second. `cache_size` increases the RAM usage, but it's capped. i chose 200MB arbitrarily but we can turn this knob later when running on real traffic

with a 200MB page cache, i found RAM usage topped off at ~150MB for my 110mb test report. profile data shows SQLite doesn't do any disk writes until the end when the transaction gets committed, and not a lot of time is spent waiting on disk IO overall. most of the time remaining is spent on index updates and such