### PR TITLE
CI: separate "normal" tests from coverage/junit-generating tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,22 +58,36 @@ jobs:
       - name: Run tests
         run: |
           cargo test
+  # This job runs tests, generates coverage data, and generates JUnit test
+  # results in a single test invocation and then uploads it all to Codecov.
+  # However, it doesn't print test results to stdout. If Codecov's failed test
+  # reporting is solid and we never need to see the results in the CI logs, we
+  # can delete the "normal" test step and just use this.
+  test-for-codecov:
+    name: Test (Upload to Codecov)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
       - name: Install `cargo llvm-cov`
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Collect coverage
+      - name: Run tests
         run: |
-          cargo llvm-cov --lcov --output-path lcov.info
-      - name: Upload to Codecov
+          cargo install cargo2junit
+          cargo llvm-cov --lcov --output-path lcov.info -- -Z unstable-options --format json --report-time | cargo2junit > results.xml
+      - name: Upload coverage data to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_ORG_TOKEN }}
-      - name: Generate JUnit test results
-        # Run tests again but with JSON output. Convert to junit then upload.
-        # The original format is nicer to look at in CI error messages.
-        run: |
-          cargo install cargo2junit
-          cargo test -- -Z unstable-options --format json --report-time | cargo2junit > results.xml
-      - name: Upload test results
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
           file: ./results.xml


### PR DESCRIPTION
https://github.com/codecov/codecov-rs/pull/12 failed a test but didn't get a test results comment because the later steps in the "Test" CI job were skipped on failure

this PR separates things into two test jobs:
- "Test", which just runs `cargo test` and prints the regular output to stdout
- "Test (Upload to Codecov)", which wraps `cargo test` in `cargo llvm-cov` and `cargo2junit` to emit coverage/test results and then uploads it all to Codecov

the second one does not print any test results to stdout, so if there are failures we will only be able to see them in the Codecov test results comment. if that comment is useful enough that we never need to look at the logs for the first one, then we can get rid of the first one