### PR TITLE
[wip] get rid of joint PK, just use local_*_id

### DIFF
--- a/migrations/01-init/up.sql
+++ b/migrations/01-init/up.sql
@@ -63,7 +63,7 @@ CREATE TABLE coverage_sample (
     raw_upload_id INTEGER REFERENCES raw_upload(id) NOT NULL,
 
     -- This should be an application-managed auto-incremented integer.
-    local_sample_id INTEGER NOT NULL,
+    local_sample_id INTEGER PRIMARY KEY,
 
     source_file_id INTEGER REFERENCES source_file(id) NOT NULL,
     line_no INTEGER NOT NULL,
@@ -71,9 +71,9 @@ CREATE TABLE coverage_sample (
     coverage_type VARCHAR NOT NULL,
     hits INTEGER,
     hit_branches INTEGER,
-    total_branches INTEGER,
+    total_branches INTEGER
 
-    PRIMARY KEY (raw_upload_id, local_sample_id)
+    -- PRIMARY KEY (raw_upload_id, local_sample_id)
 );
 
 -- TODO: Measure size/perf impact of making this table `WITHOUT ROWID`
@@ -82,16 +82,16 @@ CREATE TABLE branches_data (
     local_sample_id INTEGER NOT NULL,
 
     -- This should be an application-managed auto-incremented integer.
-    local_branch_id INTEGER NOT NULL,
+    local_branch_id INTEGER PRIMARY KEY,
 
     source_file_id INTEGER REFERENCES source_file(id) NOT NULL,
 
     hits INTEGER NOT NULL,
     branch_format VARCHAR NOT NULL,
-    branch VARCHAR NOT NULL,
+    branch VARCHAR NOT NULL
 
-    FOREIGN KEY (raw_upload_id, local_sample_id) REFERENCES coverage_sample(raw_upload_id, local_sample_id),
-    PRIMARY KEY (raw_upload_id, local_branch_id)
+    -- FOREIGN KEY (raw_upload_id, local_sample_id) REFERENCES coverage_sample(raw_upload_id, local_sample_id),
+    -- PRIMARY KEY (raw_upload_id, local_branch_id)
 );
 
 -- TODO: Measure size/perf impact of making this table `WITHOUT ROWID`
@@ -100,7 +100,7 @@ CREATE TABLE method_data (
     local_sample_id INTEGER NOT NULL,
 
     -- This should be an application-managed auto-incremented integer.
-    local_method_id INTEGER NOT NULL,
+    local_method_id INTEGER PRIMARY KEY,
 
     source_file_id INTEGER REFERENCES source_file(id) NOT NULL,
     line_no INTEGER,
@@ -108,16 +108,16 @@ CREATE TABLE method_data (
     hit_branches INTEGER,
     total_branches INTEGER,
     hit_complexity_paths INTEGER,
-    total_complexity INTEGER,
+    total_complexity INTEGER
 
-    FOREIGN KEY (raw_upload_id, local_sample_id) REFERENCES coverage_sample(raw_upload_id, local_sample_id),
-    PRIMARY KEY (raw_upload_id, local_method_id)
+    -- FOREIGN KEY (raw_upload_id, local_sample_id) REFERENCES coverage_sample(raw_upload_id, local_sample_id),
+    -- PRIMARY KEY (raw_upload_id, local_method_id)
 );
 
 -- TODO: Measure size/perf impact of making this table `WITHOUT ROWID`
 CREATE TABLE span_data (
     raw_upload_id INTEGER REFERENCES raw_upload(id) NOT NULL,
-    local_sample_id INTEGER,
+    local_sample_id INTEGER PRIMARY KEY,
 
     -- This should be an application-managed auto-incremented integer.
     local_span_id INTEGER NOT NULL,
@@ -128,8 +128,8 @@ CREATE TABLE span_data (
     start_line INTEGER,
     start_col INTEGER,
     end_line INTEGER,
-    end_col INTEGER,
+    end_col INTEGER
 
-    FOREIGN KEY (raw_upload_id, local_sample_id) REFERENCES coverage_sample(raw_upload_id, local_sample_id),
-    PRIMARY KEY (raw_upload_id, local_span_id)
+    -- FOREIGN KEY (raw_upload_id, local_sample_id) REFERENCES coverage_sample(raw_upload_id, local_sample_id),
+    -- PRIMARY KEY (raw_upload_id, local_span_id)
 );


### PR DESCRIPTION
### not currently working on this, just an idea for later

the idea behind the joint PK is that it makes records globally unique if we distribute processing to different hosts. when we merge all the reports together at the end, we can just union the tables and not worry about non-unique IDs or updating foreign keys

while the joint PK is way better than UUIDs perf-wise, profile data still shows a lot of time is spent updating indexes for the joint PK. if we switch to `INTEGER PRIMARY KEY` it's a good deal faster. a specific comparison:
- using the joint PK, one profile spends 1.94s in `sqlite3VdbeExec`, with 1.04s of that in `sqlite3BTreeIndexMoveto`
- without the joint PK, the profile spends 868ms in `sqlite3VdbeExec` with 324ms of that in `sqlite3BTreeIndexMoveto`
- overall runtime with the joint pk was 6.34s, overall runtime without it was 5.22s

merging is also really an INSERT, so it also has to pay for index updates. while switching to `INTEGER PRIMARY KEY` would necessitate more work to update foreign keys, it's not clear whether that cost outweighs the savings from making index updates faster in both places

to decide whether to make this change, we need some data around merging:
- how much does this change the perf of merging (good or bad) for small inputs? large inputs?
- we expect to merge incremental results one-by-one into a final report, rather than merging two large final reports. what size is the typical incremental result?