### PR TITLE
Add a benchmark for `report_json` parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ target/
 
 # Vim swapfiles
 .*.sw*
+
+/reports
+lcov.info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -45,9 +45,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
 name = "codecov-rs"
 version = "0.1.0"
 dependencies = [
+ "divan",
  "include_dir",
  "lazy_static",
  "memmap2",
@@ -65,6 +92,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
+
+[[package]]
+name = "divan"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d567df2c9c2870a43f3f2bd65aaeb18dbce1c18f217c3e564b4fbaeb3ee56c"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27540baf49be0d484d8f0130d7d8da3011c32a44d4fc873368154f1510e574a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,7 +135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -254,12 +312,11 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288c0e17cc8d342c712bb43a257a80ebffce59cdb33d5000d8348f3ec02528b"
+checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
 dependencies = [
- "zerocopy",
- "zerocopy-derive",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -337,6 +394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,7 +434,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -469,7 +532,17 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -524,11 +597,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -537,15 +634,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -555,9 +658,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -573,9 +688,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -585,9 +712,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -606,12 +745,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,13 @@ name = "codecov-rs"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["pyreport"]
+pyreport = []
+
+[profile.release]
+debug = 1
+
 [dependencies]
 rusqlite = { version = "0.31.0", features = ["bundled", "limits"] }
 rusqlite_migration = { version = "1.2.0", features = ["from-directory"] }
@@ -31,10 +38,10 @@ winnow = "0.5.34"
 serde_json = "1.0.117"
 
 [dev-dependencies]
-tempfile = "3.9.0"
+divan = "0.1.14"
 mockall = { version = "0.13.0", features = ["nightly"] }
+tempfile = "3.9.0"
 
-[features]
-default = ["pyreport"]
-
-pyreport = []
+[[bench]]
+name = "pyreport"
+harness = false

--- a/benches/pyreport.rs
+++ b/benches/pyreport.rs
@@ -1,0 +1,198 @@
+use codecov_rs::{
+    error::Result,
+    parsers::{common::ReportBuilderCtx, pyreport::report_json},
+    report::{models, Report, ReportBuilder},
+};
+use divan::Bencher;
+use winnow::Parser as _;
+
+fn main() {
+    divan::main();
+}
+
+#[divan::bench]
+fn simple_report() {
+    let reports = &[
+        r#"{"files": {"src/report.rs": [0, {}, [], null]}, "sessions": {"0": {"j": "codecov-rs CI"}}}"#,
+        r#"{"files": {"src/report.rs": [0, {}, [], null], "src/report/models.rs": [1, {}, [], null]}, "sessions": {"0": {"j": "codecov-rs CI"}, "1": {"j": "codecov-rs CI 2"}}}"#,
+        r#"{"files": {}, "sessions": {"0": {"j": "codecov-rs CI"}, "1": {"j": "codecov-rs CI 2"}}}"#,
+        r#"{"files": {"src/report.rs": [0, {}, [], null], "src/report/models.rs": [1, {}, [], null]}, "sessions": {}}"#,
+        r#"{"files": {}, "sessions": {}}"#,
+    ];
+
+    for input in reports {
+        run_parsing(input);
+    }
+}
+
+// parsing this is quite slow
+#[divan::bench(sample_count = 10)]
+fn complex_report(bencher: Bencher) {
+    // this is a ~11M `report_json`
+    let path = "./reports/worker-c71ddfd4cb1753c7a540e5248c2beaa079fc3341-report_json.json";
+    if let Ok(report) = std::fs::read_to_string(path) {
+        bencher.bench(|| run_parsing(&report));
+    }
+}
+
+fn run_parsing(input: &str) {
+    let report_builder = TestReport::default();
+    let mut stream = report_json::ReportOutputStream::<&str, TestReport, TestReport> {
+        input,
+        state: ReportBuilderCtx::new(report_builder),
+    };
+    report_json::parse_report_json
+        .parse_next(&mut stream)
+        .unwrap();
+}
+
+#[derive(Debug, Default)]
+struct TestReport {
+    files: Vec<models::SourceFile>,
+    uploads: Vec<models::RawUpload>,
+}
+
+impl Report for TestReport {
+    fn list_files(&self) -> Result<Vec<models::SourceFile>> {
+        todo!()
+    }
+
+    fn list_contexts(&self) -> Result<Vec<models::Context>> {
+        todo!()
+    }
+
+    fn list_coverage_samples(&self) -> Result<Vec<models::CoverageSample>> {
+        todo!()
+    }
+
+    fn list_branches_for_sample(
+        &self,
+        _sample: &models::CoverageSample,
+    ) -> Result<Vec<models::BranchesData>> {
+        todo!()
+    }
+
+    fn get_method_for_sample(
+        &self,
+        _sample: &models::CoverageSample,
+    ) -> Result<Option<models::MethodData>> {
+        todo!()
+    }
+
+    fn list_spans_for_sample(
+        &self,
+        _sample: &models::CoverageSample,
+    ) -> Result<Vec<models::SpanData>> {
+        todo!()
+    }
+
+    fn list_contexts_for_sample(
+        &self,
+        _sample: &models::CoverageSample,
+    ) -> Result<Vec<models::Context>> {
+        todo!()
+    }
+
+    fn list_samples_for_file(
+        &self,
+        _file: &models::SourceFile,
+    ) -> Result<Vec<models::CoverageSample>> {
+        todo!()
+    }
+
+    fn list_raw_uploads(&self) -> Result<Vec<models::RawUpload>> {
+        todo!()
+    }
+
+    fn merge(&mut self, _other: &Self) -> Result<()> {
+        todo!()
+    }
+
+    fn totals(&self) -> Result<models::ReportTotals> {
+        todo!()
+    }
+}
+
+impl ReportBuilder<TestReport> for TestReport {
+    fn insert_file(&mut self, path: String) -> Result<models::SourceFile> {
+        let file = models::SourceFile {
+            id: seahash::hash(path.as_bytes()) as i64,
+            path,
+        };
+        self.files.push(file.clone());
+        Ok(file)
+    }
+
+    fn insert_raw_upload(
+        &mut self,
+        mut upload_details: models::RawUpload,
+    ) -> Result<models::RawUpload> {
+        upload_details.id = self.uploads.len() as i64;
+        self.uploads.push(upload_details.clone());
+        Ok(upload_details)
+    }
+
+    fn insert_context(
+        &mut self,
+        _context_type: models::ContextType,
+        _name: &str,
+    ) -> Result<models::Context> {
+        todo!()
+    }
+
+    fn insert_coverage_sample(
+        &mut self,
+        _sample: models::CoverageSample,
+    ) -> Result<models::CoverageSample> {
+        todo!()
+    }
+
+    fn multi_insert_coverage_sample(
+        &mut self,
+        _samples: Vec<&mut models::CoverageSample>,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    fn insert_branches_data(
+        &mut self,
+        _branch: models::BranchesData,
+    ) -> Result<models::BranchesData> {
+        todo!()
+    }
+
+    fn multi_insert_branches_data(
+        &mut self,
+        _branches: Vec<&mut models::BranchesData>,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    fn insert_method_data(&mut self, _method: models::MethodData) -> Result<models::MethodData> {
+        todo!()
+    }
+
+    fn multi_insert_method_data(&mut self, _methods: Vec<&mut models::MethodData>) -> Result<()> {
+        todo!()
+    }
+
+    fn insert_span_data(&mut self, _span: models::SpanData) -> Result<models::SpanData> {
+        todo!()
+    }
+
+    fn multi_insert_span_data(&mut self, _spans: Vec<&mut models::SpanData>) -> Result<()> {
+        todo!()
+    }
+
+    fn associate_context(&mut self, _assoc: models::ContextAssoc) -> Result<models::ContextAssoc> {
+        todo!()
+    }
+
+    fn multi_associate_context(&mut self, _assocs: Vec<&mut models::ContextAssoc>) -> Result<()> {
+        todo!()
+    }
+
+    fn build(self) -> Result<Self> {
+        Ok(self)
+    }
+}


### PR DESCRIPTION
This currently yields the following numbers for me locally:

```
pyreport           fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ complex_report  452.4 ms      │ 489.2 ms      │ 465 ms        │ 466.9 ms      │ 10      │ 10
╰─ simple_report   17.27 µs      │ 224 µs        │ 18.12 µs      │ 19.79 µs      │ 25076   │ 25076
```