### PR TITLE
Parse `report_json` files with serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,12 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.8"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -52,18 +55,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -87,6 +90,7 @@ dependencies = [
  "rusqlite",
  "rusqlite_migration",
  "seahash",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror",
@@ -156,9 +160,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "getrandom"
@@ -228,9 +232,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -380,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -450,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags",
  "errno",
@@ -475,18 +479,18 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"
-version = "1.0.205"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.205"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -495,15 +499,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
@@ -513,9 +523,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,4 @@ members = ["bindings", "core"]
 default-members = ["core"]
 
 [profile.release]
-
 debug = 1

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = ["pyreport"]
 pyreport = []
+testing = []
 
 [dependencies]
 include_dir = "0.7.3"
@@ -14,6 +15,7 @@ rand = "0.8.5"
 rusqlite = { version = "0.31.0", features = ["bundled", "limits"] }
 rusqlite_migration = { version = "1.2.0", features = ["from-directory"] }
 seahash = "4.1.0"
+serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.117"
 thiserror = "1.0.59"
 winnow = "0.5.34"
@@ -25,3 +27,4 @@ tempfile = "3.9.0"
 [[bench]]
 name = "pyreport"
 harness = false
+required-features = ["testing"]

--- a/core/benches/pyreport.rs
+++ b/core/benches/pyreport.rs
@@ -1,10 +1,5 @@
-use codecov_rs::{
-    error::Result,
-    parsers::{common::ReportBuilderCtx, pyreport::report_json},
-    report::{models, Report, ReportBuilder},
-};
+use codecov_rs::{parsers::pyreport::report_json, report::test::TestReportBuilder};
 use divan::Bencher;
-use winnow::Parser as _;
 
 fn main() {
     divan::main();
@@ -13,11 +8,11 @@ fn main() {
 #[divan::bench]
 fn simple_report() {
     let reports = &[
-        r#"{"files": {"src/report.rs": [0, {}, [], null]}, "sessions": {"0": {"j": "codecov-rs CI"}}}"#,
-        r#"{"files": {"src/report.rs": [0, {}, [], null], "src/report/models.rs": [1, {}, [], null]}, "sessions": {"0": {"j": "codecov-rs CI"}, "1": {"j": "codecov-rs CI 2"}}}"#,
-        r#"{"files": {}, "sessions": {"0": {"j": "codecov-rs CI"}, "1": {"j": "codecov-rs CI 2"}}}"#,
-        r#"{"files": {"src/report.rs": [0, {}, [], null], "src/report/models.rs": [1, {}, [], null]}, "sessions": {}}"#,
-        r#"{"files": {}, "sessions": {}}"#,
+        &br#"{"files": {"src/report.rs": [0, {}, [], null]}, "sessions": {"0": {"j": "codecov-rs CI"}}}"#[..],
+        &br#"{"files": {"src/report.rs": [0, {}, [], null], "src/report/models.rs": [1, {}, [], null]}, "sessions": {"0": {"j": "codecov-rs CI"}, "1": {"j": "codecov-rs CI 2"}}}"#[..],
+        &br#"{"files": {}, "sessions": {"0": {"j": "codecov-rs CI"}, "1": {"j": "codecov-rs CI 2"}}}"#[..],
+        &br#"{"files": {"src/report.rs": [0, {}, [], null], "src/report/models.rs": [1, {}, [], null]}, "sessions": {}}"#[..],
+        &br#"{"files": {}, "sessions": {}}"#[..],
     ];
 
     for input in reports {
@@ -26,17 +21,17 @@ fn simple_report() {
 }
 
 // parsing this is quite slow
-#[divan::bench(sample_count = 10)]
+#[divan::bench]
 fn complex_report(bencher: Bencher) {
     // this is a ~11M `report_json`
     let path =
         "./fixtures/pyreport/large/worker-c71ddfd4cb1753c7a540e5248c2beaa079fc3341-report_json.json";
-    let Ok(report) = std::fs::read_to_string(path) else {
+    let Ok(report) = std::fs::read(path) else {
         println!("Failed to read test report");
         return;
     };
 
-    if report.starts_with("version https://git-lfs.github.com/spec/v1\n") {
+    if report.starts_with(b"version https://git-lfs.github.com/spec/v1\n") {
         println!("Sample report has not been pulled from Git LFS");
         return;
     }
@@ -44,157 +39,7 @@ fn complex_report(bencher: Bencher) {
     bencher.bench(|| run_parsing(&report));
 }
 
-fn run_parsing(input: &str) {
-    let report_builder = TestReport::default();
-    let mut stream = report_json::ReportOutputStream::<&str, TestReport, TestReport> {
-        input,
-        state: ReportBuilderCtx::new(report_builder),
-    };
-    report_json::parse_report_json
-        .parse_next(&mut stream)
-        .unwrap();
-}
-
-#[derive(Debug, Default)]
-struct TestReport {
-    files: Vec<models::SourceFile>,
-    uploads: Vec<models::RawUpload>,
-}
-
-impl Report for TestReport {
-    fn list_files(&self) -> Result<Vec<models::SourceFile>> {
-        todo!()
-    }
-
-    fn list_contexts(&self) -> Result<Vec<models::Context>> {
-        todo!()
-    }
-
-    fn list_coverage_samples(&self) -> Result<Vec<models::CoverageSample>> {
-        todo!()
-    }
-
-    fn list_branches_for_sample(
-        &self,
-        _sample: &models::CoverageSample,
-    ) -> Result<Vec<models::BranchesData>> {
-        todo!()
-    }
-
-    fn get_method_for_sample(
-        &self,
-        _sample: &models::CoverageSample,
-    ) -> Result<Option<models::MethodData>> {
-        todo!()
-    }
-
-    fn list_spans_for_sample(
-        &self,
-        _sample: &models::CoverageSample,
-    ) -> Result<Vec<models::SpanData>> {
-        todo!()
-    }
-
-    fn list_contexts_for_sample(
-        &self,
-        _sample: &models::CoverageSample,
-    ) -> Result<Vec<models::Context>> {
-        todo!()
-    }
-
-    fn list_samples_for_file(
-        &self,
-        _file: &models::SourceFile,
-    ) -> Result<Vec<models::CoverageSample>> {
-        todo!()
-    }
-
-    fn list_raw_uploads(&self) -> Result<Vec<models::RawUpload>> {
-        todo!()
-    }
-
-    fn merge(&mut self, _other: &Self) -> Result<()> {
-        todo!()
-    }
-
-    fn totals(&self) -> Result<models::ReportTotals> {
-        todo!()
-    }
-}
-
-impl ReportBuilder<TestReport> for TestReport {
-    fn insert_file(&mut self, path: &str) -> Result<models::SourceFile> {
-        let file = models::SourceFile::new(path);
-        self.files.push(file.clone());
-        Ok(file)
-    }
-
-    fn insert_raw_upload(
-        &mut self,
-        mut upload_details: models::RawUpload,
-    ) -> Result<models::RawUpload> {
-        upload_details.id = self.uploads.len() as i64;
-        self.uploads.push(upload_details.clone());
-        Ok(upload_details)
-    }
-
-    fn insert_context(&mut self, _name: &str) -> Result<models::Context> {
-        todo!()
-    }
-
-    fn insert_coverage_sample(
-        &mut self,
-        _sample: models::CoverageSample,
-    ) -> Result<models::CoverageSample> {
-        todo!()
-    }
-
-    fn multi_insert_coverage_sample(
-        &mut self,
-        _samples: Vec<&mut models::CoverageSample>,
-    ) -> Result<()> {
-        todo!()
-    }
-
-    fn insert_branches_data(
-        &mut self,
-        _branch: models::BranchesData,
-    ) -> Result<models::BranchesData> {
-        todo!()
-    }
-
-    fn multi_insert_branches_data(
-        &mut self,
-        _branches: Vec<&mut models::BranchesData>,
-    ) -> Result<()> {
-        todo!()
-    }
-
-    fn insert_method_data(&mut self, _method: models::MethodData) -> Result<models::MethodData> {
-        todo!()
-    }
-
-    fn multi_insert_method_data(&mut self, _methods: Vec<&mut models::MethodData>) -> Result<()> {
-        todo!()
-    }
-
-    fn insert_span_data(&mut self, _span: models::SpanData) -> Result<models::SpanData> {
-        todo!()
-    }
-
-    fn multi_insert_span_data(&mut self, _spans: Vec<&mut models::SpanData>) -> Result<()> {
-        todo!()
-    }
-
-    fn associate_context(&mut self, _assoc: models::ContextAssoc) -> Result<models::ContextAssoc> {
-        todo!()
-    }
-
-    fn multi_associate_context(&mut self, _assocs: Vec<&mut models::ContextAssoc>) -> Result<()> {
-        todo!()
-    }
-
-    fn build(self) -> Result<Self> {
-        Ok(self)
-    }
+fn run_parsing(input: &[u8]) {
+    let mut report_builder = TestReportBuilder::default();
+    report_json::parse_report_json(input, &mut report_builder).unwrap();
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -17,6 +17,9 @@ pub enum CodecovError {
     #[error("parser error: '{0}'")]
     ParserError(winnow::error::ContextError),
 
+    #[error("parser error: '{0}'")]
+    Json(#[from] serde_json::Error),
+
     #[error("io error: '{0}'")]
     IOError(#[from] std::io::Error),
 

--- a/core/src/report/mod.rs
+++ b/core/src/report/mod.rs
@@ -6,7 +6,7 @@ pub use sqlite::{SqliteReport, SqliteReportBuilder, SqliteReportBuilderTx};
 #[cfg(feature = "pyreport")]
 pub mod pyreport;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub mod test;
 
 use crate::error::Result;


### PR DESCRIPTION
Replaces the hand-written `winnow`-based parser with a bunch of struct definitions along with deriving `serde::Deserialize`.

---

The Serde definitions look very simple, and parsing performance seems to be 8-20x faster than the hand built parser, and doing a lot less less intermediate allocations.

This is a previous comparison:

```
pyreport              fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ serde                            │               │               │               │         │
│  ├─ complex_report  19.47 ms      │ 25.82 ms      │ 21.48 ms      │ 21.66 ms      │ 23      │ 23
│  │                  alloc:        │               │               │               │         │
│  │                    1629        │ 0             │ 1629          │ 1558          │         │
│  │                    401.6 KB    │ 0 B           │ 401.6 KB      │ 384.2 KB      │         │
│  │                  dealloc:      │               │               │               │         │
│  │                    14          │ 0             │ 14            │ 13.39         │         │
│  │                    91.82 KB    │ 0 B           │ 91.82 KB      │ 87.83 KB      │         │
│  ╰─ simple_report   2.017 µs      │ 155.4 µs      │ 2.12 µs       │ 2.4 µs        │ 182288  │ 182288
│                     alloc:        │               │               │               │         │
│                       6           │ 6             │ 6             │ 6             │         │
│                       4.056 KB    │ 4.056 KB      │ 4.056 KB      │ 4.056 KB      │         │
│                     dealloc:      │               │               │               │         │
│                       6           │ 6             │ 6             │ 6             │         │
│                       4.056 KB    │ 4.056 KB      │ 4.056 KB      │ 4.056 KB      │         │
╰─ winnow                           │               │               │               │         │
   ├─ complex_report  471 ms        │ 516.1 ms      │ 497.7 ms      │ 495.7 ms      │ 10      │ 10
   │                  alloc:        │               │               │               │         │
   │                    1020786     │ 1020786       │ 1020786       │ 1020786       │         │
   │                    81.6 MB     │ 81.6 MB       │ 81.6 MB       │ 81.6 MB       │         │
   │                  dealloc:      │               │               │               │         │
   │                    1020784     │ 1020784       │ 1020784       │ 1020784       │         │
   │                    122.4 MB    │ 122.4 MB      │ 122.4 MB      │ 122.4 MB      │         │
   │                  grow:         │               │               │               │         │
   │                    322539      │ 322539        │ 322539        │ 322539        │         │
   │                    40.89 MB    │ 40.89 MB      │ 40.89 MB      │ 40.89 MB      │         │
   ╰─ simple_report   14.31 µs      │ 168.7 µs      │ 16.18 µs      │ 17.38 µs      │ 28158   │ 28158
                      alloc:        │               │               │               │         │
                        51          │ 51            │ 51            │ 51            │         │
                        4.613 KB    │ 4.613 KB      │ 4.613 KB      │ 4.613 KB      │         │
                      dealloc:      │               │               │               │         │
                        51          │ 51            │ 51            │ 51            │         │
                        4.725 KB    │ 4.725 KB      │ 4.725 KB      │ 4.725 KB      │         │
                      grow:         │               │               │               │         │
                        12          │ 12            │ 12            │ 12            │         │
                        112 B       │ 112 B         │ 112 B         │ 112 B         │         │

```