### PR TITLE
add pre-commit configuration for cargo fmt and clippy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: local
+    hooks:
+      - id: format
+        name: cargo fmt
+        entry: cargo fmt
+        args: ["--check", "--"]
+        require_serial: true
+        language: system
+        types: [rust]
+      - id: clippy
+        name: cargo clippy
+        entry: cargo clippy
+        args: ["--", "-D", "warnings"]
+        require_serial: true
+        pass_filenames: false
+        types: [rust]
+        language: system

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The `examples/` directory contains runnable commands for developers including:
 
 Considering following suit for your own new feature.
 
+Install lint hooks with `pip install pre-commit && pre-commit install`.
+
 ### Writing new parsers
 
 **TBD: Design not settled**


### PR DESCRIPTION
`pip install pre-commit && pre-commit install` should work. i'm actually using sapling instead of git right now so i haven't tested it, but the hooks themselves are working in my sapling config

this will prevent you from committing if there are any rustfmt gripes or clippy warnings/errors