### PR TITLE
check in large pyreport sample using git-lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+fixtures/**/large/ filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ target/
 # Vim swapfiles
 .*.sw*
 
-/reports
+.git
 lcov.info

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,3 @@
+[lfs]
+        pushurl = git@github.com:codecov/codecov-rs
+        url = git@github.com:codecov/codecov-rs

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Considering following suit for your own new feature.
 
 Install lint hooks with `pip install pre-commit && pre-commit install`.
 
+Large sample test reports are checked in using [Git LFS](https://git-lfs.com/). Tests and benchmarks may reference them so installing it yourself is recommended.
+
 ### Writing new parsers
 
 **TBD: Design not settled**
@@ -53,4 +55,11 @@ Non-XML formats lack clean OOTB support for streaming so `codecov-rs` currently 
 Run tests with:
 ```
 $ cargo test
+```
+
+### Benchmarks
+
+Run benchmarks with:
+```
+$ cargo bench
 ```

--- a/benches/pyreport.rs
+++ b/benches/pyreport.rs
@@ -29,10 +29,19 @@ fn simple_report() {
 #[divan::bench(sample_count = 10)]
 fn complex_report(bencher: Bencher) {
     // this is a ~11M `report_json`
-    let path = "./reports/worker-c71ddfd4cb1753c7a540e5248c2beaa079fc3341-report_json.json";
-    if let Ok(report) = std::fs::read_to_string(path) {
-        bencher.bench(|| run_parsing(&report));
+    let path =
+        "./fixtures/pyreport/large/worker-c71ddfd4cb1753c7a540e5248c2beaa079fc3341-report_json.json";
+    let Ok(report) = std::fs::read_to_string(path) else {
+        println!("Failed to read test report");
+        return;
+    };
+
+    if report.starts_with("version https://git-lfs.github.com/spec/v1\n") {
+        println!("Sample report has not been pulled from Git LFS");
+        return;
     }
+
+    bencher.bench(|| run_parsing(&report));
 }
 
 fn run_parsing(input: &str) {

--- a/fixtures/pyreport/large/worker-c71ddfd4cb1753c7a540e5248c2beaa079fc3341-chunks.txt
+++ b/fixtures/pyreport/large/worker-c71ddfd4cb1753c7a540e5248c2beaa079fc3341-chunks.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea86676350ec704e77e0f8cfcab9354fb9d207cadf48ab823f4c4db328a87def
+size 101127088

--- a/fixtures/pyreport/large/worker-c71ddfd4cb1753c7a540e5248c2beaa079fc3341-report_json.json
+++ b/fixtures/pyreport/large/worker-c71ddfd4cb1753c7a540e5248c2beaa079fc3341-report_json.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7351ef233283771366eb0638753e63a02df510f1fcfdefb32c084e58b6528b92
+size 11159601


### PR DESCRIPTION
[Git LFS](https://git-lfs.com/) is a git extension that lets you check in "pointers" to large files and upload the files themselves to a separate LFS store (for us, that's GitHub's LFS server). it's powered by git hooks that make it seem as though the large files are actually in the repository when you're working with it locally

using it for large sample reports will let us write benchmarks or integration tests against large, real-world data without bloating the repository

```
$ brew install git-lfs
$ cd /path/to/codecov-rs
$ git lfs install
```

if we want to use LFS files in CI jobs, we will need to tell the checkout step to check out LFS files too somehow