### PR TITLE
Fix git lfs glob pattern

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,3 @@
+[lfs]
+        pushurl = git@github.com:codecov/codecov-rs
+        url = git@github.com:codecov/codecov-rs


### PR DESCRIPTION
I had quite some trouble getting git lfs running locally, which came down to two problems:

- ~LFS was using SSH auth instead of HTTPS auth for some reason. I fixed that by registering my SSH key, and properly setting up SSO for it. Nothing major, just an annoyance. Nevertheless, I removed the explicit `.lfsconfig`, as git should inherit those urls from the primary remote.~

- For some reason, I ended up in this weird state where LFS would properly resolve files, but then git itself was confused and considered those files to be modified and staged for commit. This prevented me from pulling and switching branches because "you have uncommited changes". Doing the commit as git suggested would indeed actually commit the files, and not go through the git filter. No idea whats happening here, but looks like git and lfs disagree on how to interpret the glob patterns in the `.gitattributes`, so I made those more explicit, and now both agree and git will not flag those files as "ready for commit" anymore.

---

Please try these changes locally to see if they work correctly with `sapling`.