### PR TITLE
Remove unused `ContextType` and other simplifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -34,9 +34,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
 
 [[package]]
 name = "cfg-if"
@@ -76,7 +76,6 @@ version = "0.1.0"
 dependencies = [
  "divan",
  "include_dir",
- "lazy_static",
  "memmap2",
  "mockall",
  "rand",
@@ -84,8 +83,6 @@ dependencies = [
  "rusqlite_migration",
  "seahash",
  "serde_json",
- "strum",
- "strum_macros",
  "tempfile",
  "thiserror",
  "winnow",
@@ -192,12 +189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,12 +212,6 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -312,11 +297,11 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -438,12 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,18 +436,18 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -477,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
  "memchr",
@@ -494,25 +473,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,14 +485,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -609,6 +570,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -745,32 +715,12 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.6.6",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "byteorder",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,31 +11,15 @@ pyreport = []
 debug = 1
 
 [dependencies]
+include_dir = "0.7.3"
+memmap2 = "0.9.4"
+rand = "0.8.5"
 rusqlite = { version = "0.31.0", features = ["bundled", "limits"] }
 rusqlite_migration = { version = "1.2.0", features = ["from-directory"] }
-rand = "0.8.5"
-
-# SeaHash chosen due to:
-# - widely used
-# - portable and stable, results don't change
-# - reads 8 bytes at a time, nice for longer inputs
-# - outputs 64 bytes
-# If we need to change it, use SQLite "schema version" to mark new versions
-# which should use a different hash function.
 seahash = "4.1.0"
-
-memmap2 = "0.9.4"
-
-include_dir = "0.7.3"
-lazy_static = "1.4.0"
-strum = "0.26.1"
-strum_macros = "0.26.1"
-
-thiserror = "1.0.59"
-
-winnow = "0.5.34"
-
 serde_json = "1.0.117"
+thiserror = "1.0.59"
+winnow = "0.5.34"
 
 [dev-dependencies]
 divan = "0.1.14"

--- a/benches/pyreport.rs
+++ b/benches/pyreport.rs
@@ -123,11 +123,8 @@ impl Report for TestReport {
 }
 
 impl ReportBuilder<TestReport> for TestReport {
-    fn insert_file(&mut self, path: String) -> Result<models::SourceFile> {
-        let file = models::SourceFile {
-            id: seahash::hash(path.as_bytes()) as i64,
-            path,
-        };
+    fn insert_file(&mut self, path: &str) -> Result<models::SourceFile> {
+        let file = models::SourceFile::new(path);
         self.files.push(file.clone());
         Ok(file)
     }
@@ -141,11 +138,7 @@ impl ReportBuilder<TestReport> for TestReport {
         Ok(upload_details)
     }
 
-    fn insert_context(
-        &mut self,
-        _context_type: models::ContextType,
-        _name: &str,
-    ) -> Result<models::Context> {
+    fn insert_context(&mut self, _name: &str) -> Result<models::Context> {
         todo!()
     }
 

--- a/migrations/01-init/up.sql
+++ b/migrations/01-init/up.sql
@@ -39,7 +39,6 @@ CREATE TABLE context (
     -- all come up with the same ID.
     id INTEGER PRIMARY KEY,
 
-    context_type VARCHAR NOT NULL,
     name VARCHAR NOT NULL
 );
 

--- a/src/parsers/pyreport/report_json.rs
+++ b/src/parsers/pyreport/report_json.rs
@@ -98,7 +98,7 @@ pub fn report_file<S: StrStream, R: Report, B: ReportBuilder<R>>(
     let file = buf
         .state
         .report_builder
-        .insert_file(filename)
+        .insert_file(&filename)
         .map_err(|e| ErrMode::from_external_error(buf, ErrorKind::Fail, e))?;
 
     Ok((chunks_index as usize, file.id))
@@ -308,10 +308,7 @@ mod tests {
                 state: ctx.parse_ctx,
             };
 
-            let inserted_model = models::SourceFile {
-                id: hash_id(path),
-                path: path.to_string(),
-            };
+            let inserted_model = models::SourceFile::new(path);
 
             buf.state
                 .report_builder

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -51,14 +51,10 @@ pub trait Report {
 #[allow(clippy::needless_lifetimes)] // `automock` requires these
 pub trait ReportBuilder<R: Report> {
     /// Create a [`models::SourceFile`] record and return it.
-    fn insert_file(&mut self, path: String) -> Result<models::SourceFile>;
+    fn insert_file(&mut self, path: &str) -> Result<models::SourceFile>;
 
     /// Create a [`models::Context`] record and return it.
-    fn insert_context(
-        &mut self,
-        context_type: models::ContextType,
-        name: &str,
-    ) -> Result<models::Context>;
+    fn insert_context(&mut self, name: &str) -> Result<models::Context>;
 
     /// Create a [`models::CoverageSample`] record and return it. The passed-in
     /// model's `local_sample_id` field is ignored and overwritten with a value

--- a/src/report/pyreport/chunks.rs
+++ b/src/report/pyreport/chunks.rs
@@ -333,8 +333,8 @@ mod tests {
 
     fn build_sample_report(path: PathBuf) -> Result<SqliteReport> {
         let mut builder = SqliteReportBuilder::new_with_seed(path, 5)?;
-        let file_1 = builder.insert_file("src/report/report.rs".to_string())?;
-        let file_2 = builder.insert_file("src/report/models.rs".to_string())?;
+        let file_1 = builder.insert_file("src/report/report.rs")?;
+        let file_2 = builder.insert_file("src/report/models.rs")?;
 
         let upload_1 = builder.insert_raw_upload(models::RawUpload {
             timestamp: Some(123),
@@ -543,7 +543,7 @@ mod tests {
             ..Default::default()
         })?;
 
-        let label_1 = builder.insert_context(models::ContextType::TestCase, "test-case")?;
+        let label_1 = builder.insert_context("test-case")?;
         let _ = builder.associate_context(models::ContextAssoc {
             context_id: label_1.id,
             raw_upload_id: upload_1.id,
@@ -557,7 +557,7 @@ mod tests {
             ..Default::default()
         })?;
 
-        let label_2 = builder.insert_context(models::ContextType::TestCase, "test-case 2")?;
+        let label_2 = builder.insert_context("test-case 2")?;
         let _ = builder.associate_context(models::ContextAssoc {
             context_id: label_2.id,
             raw_upload_id: upload_1.id,

--- a/src/report/pyreport/report_json.rs
+++ b/src/report/pyreport/report_json.rs
@@ -340,8 +340,8 @@ mod tests {
 
     fn build_sample_report(path: PathBuf) -> Result<SqliteReport> {
         let mut builder = SqliteReportBuilder::new_with_seed(path, 5)?;
-        let file_1 = builder.insert_file("src/report/report.rs".to_string())?;
-        let file_2 = builder.insert_file("src/report/models.rs".to_string())?;
+        let file_1 = builder.insert_file("src/report/report.rs")?;
+        let file_2 = builder.insert_file("src/report/models.rs")?;
 
         let upload_1 = builder.insert_raw_upload(models::RawUpload {
             timestamp: Some(123),
@@ -550,7 +550,7 @@ mod tests {
             ..Default::default()
         })?;
 
-        let label_1 = builder.insert_context(models::ContextType::TestCase, "test-case")?;
+        let label_1 = builder.insert_context("test-case")?;
         let _ = builder.associate_context(models::ContextAssoc {
             context_id: label_1.id,
             raw_upload_id: upload_1.id,

--- a/src/report/sqlite/mod.rs
+++ b/src/report/sqlite/mod.rs
@@ -6,10 +6,9 @@
  * - Some `ORDER BY` clauses are to make writing test cases simple and may
  *   not be necessary
  */
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::LazyLock};
 
 use include_dir::{include_dir, Dir};
-use lazy_static::lazy_static;
 use rusqlite::Connection;
 use rusqlite_migration::Migrations;
 
@@ -24,11 +23,8 @@ pub use report::*;
 pub use report_builder::*;
 
 static MIGRATIONS_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/migrations");
-
-lazy_static! {
-    static ref MIGRATIONS: Migrations<'static> =
-        Migrations::from_directory(&MIGRATIONS_DIR).unwrap();
-}
+static MIGRATIONS: LazyLock<Migrations<'static>> =
+    LazyLock::new(|| Migrations::from_directory(&MIGRATIONS_DIR).unwrap());
 
 fn open_database(filename: &PathBuf) -> Result<Connection> {
     let mut conn = Connection::open(filename)?;

--- a/src/report/sqlite/models.rs
+++ b/src/report/sqlite/models.rs
@@ -10,7 +10,7 @@
  * model.
  */
 
-use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
+use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 
 use super::super::models::*;
 use crate::{error::Result, parsers::json::JsonVal};
@@ -189,21 +189,6 @@ impl FromSql for BranchFormat {
             _ => panic!("Uh oh"),
         };
         Ok(variant)
-    }
-}
-
-impl ToSql for ContextType {
-    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
-        Ok(self.to_string().into())
-    }
-}
-
-impl FromSql for ContextType {
-    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        value
-            .as_str()?
-            .parse()
-            .map_err(|e| FromSqlError::Other(Box::new(e)))
     }
 }
 
@@ -447,7 +432,6 @@ impl<'a> std::convert::TryFrom<&'a rusqlite::Row<'a>> for Context {
     fn try_from(row: &'a ::rusqlite::Row) -> Result<Self, Self::Error> {
         Ok(Self {
             id: row.get(row.as_ref().column_index("id")?)?,
-            context_type: row.get(row.as_ref().column_index("context_type")?)?,
             name: row.get(row.as_ref().column_index("name")?)?,
         })
     }
@@ -455,12 +439,11 @@ impl<'a> std::convert::TryFrom<&'a rusqlite::Row<'a>> for Context {
 
 impl Insertable for Context {
     const TABLE_NAME: &'static str = "context";
-    const FIELDS: &'static [&'static str] = &["id", "context_type", "name"];
+    const FIELDS: &'static [&'static str] = &["id", "name"];
 
     fn extend_params<'a>(&'a self, params: &mut Vec<&'a dyn rusqlite::ToSql>) {
         params.extend(&[
             &self.id as &dyn rusqlite::ToSql,
-            &self.context_type as &dyn rusqlite::ToSql,
             &self.name as &dyn rusqlite::ToSql,
         ])
     }
@@ -689,7 +672,6 @@ mod tests {
 
         let model = Context {
             id: 0,
-            context_type: ContextType::TestCase,
             name: "test_upload".to_string(),
         };
 
@@ -715,9 +697,7 @@ mod tests {
         let raw_upload = report_builder
             .insert_raw_upload(Default::default())
             .unwrap();
-        let context = report_builder
-            .insert_context(ContextType::TestCase, "foo")
-            .unwrap();
+        let context = report_builder.insert_context("foo").unwrap();
 
         let report = report_builder.build().unwrap();
 
@@ -755,7 +735,7 @@ mod tests {
         let db_file = ctx.temp_dir.path().join("db.sqlite");
         let mut report_builder = SqliteReportBuilder::new(db_file).unwrap();
 
-        let source_file = report_builder.insert_file("foo.rs".to_string()).unwrap();
+        let source_file = report_builder.insert_file("foo.rs").unwrap();
         let raw_upload = report_builder
             .insert_raw_upload(Default::default())
             .unwrap();
@@ -788,7 +768,7 @@ mod tests {
         let db_file = ctx.temp_dir.path().join("db.sqlite");
         let mut report_builder = SqliteReportBuilder::new(db_file).unwrap();
 
-        let source_file = report_builder.insert_file("path".to_string()).unwrap();
+        let source_file = report_builder.insert_file("path").unwrap();
         let raw_upload = report_builder
             .insert_raw_upload(Default::default())
             .unwrap();
@@ -838,7 +818,7 @@ mod tests {
         let db_file = ctx.temp_dir.path().join("db.sqlite");
         let mut report_builder = SqliteReportBuilder::new(db_file).unwrap();
 
-        let source_file = report_builder.insert_file("foo.rs".to_string()).unwrap();
+        let source_file = report_builder.insert_file("foo.rs").unwrap();
         let raw_upload = report_builder
             .insert_raw_upload(Default::default())
             .unwrap();
@@ -885,7 +865,7 @@ mod tests {
         let db_file = ctx.temp_dir.path().join("db.sqlite");
         let mut report_builder = SqliteReportBuilder::new(db_file).unwrap();
 
-        let source_file = report_builder.insert_file("foo.rs".to_string()).unwrap();
+        let source_file = report_builder.insert_file("foo.rs").unwrap();
         let raw_upload = report_builder
             .insert_raw_upload(Default::default())
             .unwrap();

--- a/src/report/sqlite/queries/totals.sql
+++ b/src/report/sqlite/queries/totals.sql
@@ -9,8 +9,6 @@ select
   count(*) as count
 from
   context
-where
-  context.context_type = 'TestCase'
 ),
 files as (
 select

--- a/src/report/sqlite/report.rs
+++ b/src/report/sqlite/report.rs
@@ -40,9 +40,7 @@ impl Report for SqliteReport {
 
     // TODO: implement for real, just using for integration tests
     fn list_contexts(&self) -> Result<Vec<models::Context>> {
-        let mut stmt = self
-            .conn
-            .prepare_cached("SELECT id, context_type, name FROM context")?;
+        let mut stmt = self.conn.prepare_cached("SELECT id, name FROM context")?;
         let contexts = stmt
             .query_map([], |row| row.try_into())?
             .collect::<rusqlite::Result<Vec<models::Context>>>()?;
@@ -106,7 +104,7 @@ impl Report for SqliteReport {
     ) -> Result<Vec<models::Context>> {
         let mut stmt = self
             .conn
-            .prepare_cached("SELECT context.id, context.context_type, context.name FROM context INNER JOIN context_assoc ON context.id = context_assoc.context_id WHERE context_assoc.local_sample_id = ?1")?;
+            .prepare_cached("SELECT context.id, context.name FROM context INNER JOIN context_assoc ON context.id = context_assoc.context_id WHERE context_assoc.local_sample_id = ?1")?;
         let contexts = stmt
             .query_map([sample.local_sample_id], |row| row.try_into())?
             .collect::<rusqlite::Result<Vec<models::Context>>>()?;
@@ -217,18 +215,14 @@ mod tests {
         let db_file_right = ctx.temp_dir.path().join("right.sqlite");
 
         let mut left_report_builder = SqliteReportBuilder::new_with_seed(db_file_left, 5).unwrap();
-        let file_1 = left_report_builder
-            .insert_file("src/report.rs".to_string())
-            .unwrap();
+        let file_1 = left_report_builder.insert_file("src/report.rs").unwrap();
         let file_2 = left_report_builder
-            .insert_file("src/report/models.rs".to_string())
+            .insert_file("src/report/models.rs")
             .unwrap();
         let upload_1 = left_report_builder
             .insert_raw_upload(Default::default())
             .unwrap();
-        let test_case_1 = left_report_builder
-            .insert_context(models::ContextType::TestCase, "test case 1")
-            .unwrap();
+        let test_case_1 = left_report_builder.insert_context("test case 1").unwrap();
         let line_1 = left_report_builder
             .insert_coverage_sample(models::CoverageSample {
                 source_file_id: file_1.id,
@@ -271,17 +265,15 @@ mod tests {
         let mut right_report_builder =
             SqliteReportBuilder::new_with_seed(db_file_right, 10).unwrap();
         let file_2 = right_report_builder
-            .insert_file("src/report/models.rs".to_string())
+            .insert_file("src/report/models.rs")
             .unwrap();
         let file_3 = right_report_builder
-            .insert_file("src/report/schema.rs".to_string())
+            .insert_file("src/report/schema.rs")
             .unwrap();
         let upload_2 = right_report_builder
             .insert_raw_upload(Default::default())
             .unwrap();
-        let test_case_2 = right_report_builder
-            .insert_context(models::ContextType::TestCase, "test case 2")
-            .unwrap();
+        let test_case_2 = right_report_builder.insert_context("test case 2").unwrap();
         let line_4 = right_report_builder
             .insert_coverage_sample(models::CoverageSample {
                 raw_upload_id: upload_2.id,
@@ -378,18 +370,12 @@ mod tests {
         assert!(!db_file.exists());
         let mut report_builder = SqliteReportBuilder::new(db_file).unwrap();
 
-        let file_1 = report_builder
-            .insert_file("src/report.rs".to_string())
-            .unwrap();
-        let file_2 = report_builder
-            .insert_file("src/report/models.rs".to_string())
-            .unwrap();
+        let file_1 = report_builder.insert_file("src/report.rs").unwrap();
+        let file_2 = report_builder.insert_file("src/report/models.rs").unwrap();
         let upload_1 = report_builder
             .insert_raw_upload(Default::default())
             .unwrap();
-        let test_case_1 = report_builder
-            .insert_context(models::ContextType::TestCase, "test_totals")
-            .unwrap();
+        let test_case_1 = report_builder.insert_context("test_totals").unwrap();
         let line_1 = report_builder
             .insert_coverage_sample(models::CoverageSample {
                 raw_upload_id: upload_1.id,

--- a/tests/test_pyreport_shim.rs
+++ b/tests/test_pyreport_shim.rs
@@ -38,10 +38,6 @@ fn setup() -> Ctx {
     Ctx { temp_dir, db_file }
 }
 
-fn hash_id(key: &str) -> i64 {
-    seahash::hash(key.as_bytes()) as i64
-}
-
 #[test]
 fn test_parse_report_json() {
     let input = common::read_sample_file(Path::new("codecov-rs-reports-json-d2a9ba1.txt"));
@@ -59,18 +55,9 @@ fn test_parse_report_json() {
     };
 
     let expected_files = vec![
-        models::SourceFile {
-            id: hash_id("src/report.rs"),
-            path: "src/report.rs".to_string(),
-        },
-        models::SourceFile {
-            id: hash_id("src/report/models.rs"),
-            path: "src/report/models.rs".to_string(),
-        },
-        models::SourceFile {
-            id: hash_id("src/report/schema.rs"),
-            path: "src/report/schema.rs".to_string(),
-        },
+        models::SourceFile::new("src/report.rs"),
+        models::SourceFile::new("src/report/models.rs"),
+        models::SourceFile::new("src/report/schema.rs"),
     ];
 
     let expected_session = models::RawUpload {
@@ -132,7 +119,7 @@ fn test_parse_chunks_file() {
     .iter()
     .enumerate()
     {
-        let file = report_builder.insert_file(file.to_string()).unwrap();
+        let file = report_builder.insert_file(file).unwrap();
         report_json_files.insert(i, file.id);
     }
 
@@ -263,18 +250,9 @@ fn test_parse_pyreport() {
     };
 
     let expected_files = [
-        models::SourceFile {
-            id: hash_id("src/report.rs"),
-            path: "src/report.rs".to_string(),
-        },
-        models::SourceFile {
-            id: hash_id("src/report/models.rs"),
-            path: "src/report/models.rs".to_string(),
-        },
-        models::SourceFile {
-            id: hash_id("src/report/schema.rs"),
-            path: "src/report/schema.rs".to_string(),
-        },
+        models::SourceFile::new("src/report.rs"),
+        models::SourceFile::new("src/report/models.rs"),
+        models::SourceFile::new("src/report/schema.rs"),
     ];
 
     // Helper function for creating our expected values


### PR DESCRIPTION
- Removes `ContextType` completely, as it only had a single variant.
- Gives `SourceFile` and `Context` a constructor and simplifies its usage.
- Removes some now-unused dependencies.