### PR TITLE
Replace usage of `mockall` with explicit TestReportBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,6 @@ dependencies = [
  "divan",
  "include_dir",
  "memmap2",
- "mockall",
  "rand",
  "rusqlite",
  "rusqlite_migration",
@@ -120,12 +119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,12 +145,6 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "getrandom"
@@ -258,32 +245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,32 +263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "predicates"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
-dependencies = [
- "anstyle",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
-dependencies = [
- "predicates-core",
- "termtree",
 ]
 
 [[package]]
@@ -505,12 +440,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ winnow = "0.5.34"
 
 [dev-dependencies]
 divan = "0.1.14"
-mockall = { version = "0.13.0", features = ["nightly"] }
 tempfile = "3.9.0"
 
 [[bench]]

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,6 +1,3 @@
-#[cfg(test)]
-use mockall::automock;
-
 pub mod models;
 
 pub mod sqlite;
@@ -9,10 +6,12 @@ pub use sqlite::{SqliteReport, SqliteReportBuilder, SqliteReportBuilderTx};
 #[cfg(feature = "pyreport")]
 pub mod pyreport;
 
+#[cfg(test)]
+pub mod test;
+
 use crate::error::Result;
 
 /// An interface for coverage data.
-#[cfg_attr(test, automock)]
 pub trait Report {
     fn list_files(&self) -> Result<Vec<models::SourceFile>>;
     fn list_contexts(&self) -> Result<Vec<models::Context>>;
@@ -47,8 +46,6 @@ pub trait Report {
 }
 
 /// An interface for creating a new coverage report.
-#[cfg_attr(test, automock)]
-#[allow(clippy::needless_lifetimes)] // `automock` requires these
 pub trait ReportBuilder<R: Report> {
     /// Create a [`models::SourceFile`] record and return it.
     fn insert_file(&mut self, path: &str) -> Result<models::SourceFile>;
@@ -69,9 +66,9 @@ pub trait ReportBuilder<R: Report> {
     /// passed-in models' `local_sample_id` fields are ignored and overwritten
     /// with values that are unique among all `CoverageSample`s with the same
     /// `raw_upload_id`.
-    fn multi_insert_coverage_sample<'a>(
+    fn multi_insert_coverage_sample(
         &mut self,
-        samples: Vec<&'a mut models::CoverageSample>,
+        samples: Vec<&mut models::CoverageSample>,
     ) -> Result<()>;
 
     /// Create a [`models::BranchesData`] record and return it. The passed-in
@@ -86,9 +83,9 @@ pub trait ReportBuilder<R: Report> {
     /// passed-in models' `local_branch_id` fields are ignored and overwritten
     /// with values that are unique among all `BranchesData`s with the same
     /// `raw_upload_id`.
-    fn multi_insert_branches_data<'a>(
+    fn multi_insert_branches_data(
         &mut self,
-        branches: Vec<&'a mut models::BranchesData>,
+        branches: Vec<&mut models::BranchesData>,
     ) -> Result<()>;
 
     /// Create a [`models::MethodData`] record and return it. The passed-in
@@ -100,10 +97,7 @@ pub trait ReportBuilder<R: Report> {
     /// passed-in models' `local_method_id` fields are ignored and overwritten
     /// with values that are unique among all `MethodData`s with the same
     /// `raw_upload_id`.
-    fn multi_insert_method_data<'a>(
-        &mut self,
-        methods: Vec<&'a mut models::MethodData>,
-    ) -> Result<()>;
+    fn multi_insert_method_data(&mut self, methods: Vec<&mut models::MethodData>) -> Result<()>;
 
     /// Create a [`models::SpanData`] record and return it. The passed-in
     /// model's `local_span_id` field is ignored and overwritten with a value
@@ -114,7 +108,7 @@ pub trait ReportBuilder<R: Report> {
     /// passed-in models' `local_span_id` fields are ignored and overwritten
     /// with values that are unique among all `SpanData`s with the same
     /// `raw_upload_id`.
-    fn multi_insert_span_data<'a>(&mut self, spans: Vec<&'a mut models::SpanData>) -> Result<()>;
+    fn multi_insert_span_data(&mut self, spans: Vec<&mut models::SpanData>) -> Result<()>;
 
     /// Create a [`models::ContextAssoc`] record that associates a
     /// [`models::Context`] with another model. Returns the input to follow the
@@ -123,10 +117,7 @@ pub trait ReportBuilder<R: Report> {
 
     /// Create several [`models::ContextAssoc`] records that associate
     /// [`models::Context`]s with other models.
-    fn multi_associate_context<'a>(
-        &mut self,
-        assocs: Vec<&'a mut models::ContextAssoc>,
-    ) -> Result<()>;
+    fn multi_associate_context(&mut self, assocs: Vec<&mut models::ContextAssoc>) -> Result<()>;
 
     /// Create a [`models::RawUpload`] record and return it.
     fn insert_raw_upload(&mut self, upload_details: models::RawUpload)

--- a/src/report/test.rs
+++ b/src/report/test.rs
@@ -1,0 +1,173 @@
+use super::{
+    models::{
+        BranchesData, Context, ContextAssoc, CoverageSample, MethodData, RawUpload, SourceFile,
+        SpanData,
+    },
+    Report, ReportBuilder,
+};
+use crate::error;
+
+#[derive(Default)]
+pub struct TestReport {
+    pub files: Vec<SourceFile>,
+    pub uploads: Vec<RawUpload>,
+    pub contexts: Vec<Context>,
+    pub samples: Vec<CoverageSample>,
+    pub assocs: Vec<ContextAssoc>,
+    pub branches: Vec<BranchesData>,
+    pub methods: Vec<MethodData>,
+    pub spans: Vec<SpanData>,
+}
+
+#[derive(Default)]
+pub struct TestReportBuilder {
+    pub report: TestReport,
+}
+
+impl Report for TestReport {
+    fn list_files(&self) -> error::Result<Vec<SourceFile>> {
+        todo!()
+    }
+
+    fn list_contexts(&self) -> error::Result<Vec<Context>> {
+        todo!()
+    }
+
+    fn list_coverage_samples(&self) -> error::Result<Vec<CoverageSample>> {
+        todo!()
+    }
+
+    fn list_branches_for_sample(
+        &self,
+        _sample: &CoverageSample,
+    ) -> error::Result<Vec<BranchesData>> {
+        todo!()
+    }
+
+    fn get_method_for_sample(&self, _sample: &CoverageSample) -> error::Result<Option<MethodData>> {
+        todo!()
+    }
+
+    fn list_spans_for_sample(&self, _sample: &CoverageSample) -> error::Result<Vec<SpanData>> {
+        todo!()
+    }
+
+    fn list_contexts_for_sample(&self, _sample: &CoverageSample) -> error::Result<Vec<Context>> {
+        todo!()
+    }
+
+    fn list_samples_for_file(&self, _file: &SourceFile) -> error::Result<Vec<CoverageSample>> {
+        todo!()
+    }
+
+    fn list_raw_uploads(&self) -> error::Result<Vec<RawUpload>> {
+        todo!()
+    }
+
+    fn merge(&mut self, _other: &Self) -> error::Result<()> {
+        todo!()
+    }
+
+    fn totals(&self) -> error::Result<super::models::ReportTotals> {
+        todo!()
+    }
+}
+
+impl ReportBuilder<TestReport> for TestReportBuilder {
+    fn insert_file(&mut self, path: &str) -> error::Result<SourceFile> {
+        let file = SourceFile::new(path);
+        self.report.files.push(file.clone());
+        Ok(file)
+    }
+
+    fn insert_context(&mut self, name: &str) -> error::Result<Context> {
+        let context = Context::new(name);
+        self.report.contexts.push(context.clone());
+        Ok(context)
+    }
+
+    fn insert_coverage_sample(&mut self, sample: CoverageSample) -> error::Result<CoverageSample> {
+        self.report.samples.push(sample.clone());
+        Ok(sample)
+    }
+
+    fn multi_insert_coverage_sample(
+        &mut self,
+        samples: Vec<&mut CoverageSample>,
+    ) -> error::Result<()> {
+        self.report
+            .samples
+            .extend(samples.into_iter().enumerate().map(|(i, m)| {
+                m.local_sample_id = i as i64;
+                m.clone()
+            }));
+        Ok(())
+    }
+
+    fn insert_branches_data(&mut self, branch: BranchesData) -> error::Result<BranchesData> {
+        self.report.branches.push(branch.clone());
+        Ok(branch)
+    }
+
+    fn multi_insert_branches_data(
+        &mut self,
+        branches: Vec<&mut BranchesData>,
+    ) -> error::Result<()> {
+        self.report
+            .branches
+            .extend(branches.into_iter().map(|m| m.clone()));
+        Ok(())
+    }
+
+    fn insert_method_data(&mut self, method: MethodData) -> error::Result<MethodData> {
+        self.report.methods.push(method.clone());
+        Ok(method)
+    }
+
+    fn multi_insert_method_data(&mut self, methods: Vec<&mut MethodData>) -> error::Result<()> {
+        self.report
+            .methods
+            .extend(methods.into_iter().map(|m| m.clone()));
+        Ok(())
+    }
+
+    fn insert_span_data(&mut self, span: SpanData) -> error::Result<SpanData> {
+        self.report.spans.push(span.clone());
+        Ok(span)
+    }
+
+    fn multi_insert_span_data(&mut self, spans: Vec<&mut SpanData>) -> error::Result<()> {
+        self.report
+            .spans
+            .extend(spans.into_iter().map(|s| s.clone()));
+        Ok(())
+    }
+
+    fn associate_context(
+        &mut self,
+        assoc: super::models::ContextAssoc,
+    ) -> error::Result<super::models::ContextAssoc> {
+        self.report.assocs.push(assoc.clone());
+        Ok(assoc)
+    }
+
+    fn multi_associate_context(
+        &mut self,
+        assocs: Vec<&mut super::models::ContextAssoc>,
+    ) -> error::Result<()> {
+        self.report
+            .assocs
+            .extend(assocs.into_iter().map(|m| m.clone()));
+        Ok(())
+    }
+
+    fn insert_raw_upload(&mut self, mut upload_details: RawUpload) -> error::Result<RawUpload> {
+        upload_details.id = self.report.uploads.len() as i64;
+        self.report.uploads.push(upload_details.clone());
+        Ok(upload_details)
+    }
+
+    fn build(self) -> error::Result<TestReport> {
+        Ok(self.report)
+    }
+}


### PR DESCRIPTION
The new `TestReportBuilder` collects all of the input fed into it. This way one can run assertions on the collected inputs, instead of asserting functions being called.

---

This might be a bit controversial, as it is a personal preference to avoid mocks.
The practical advantage is that avoiding `mockall` brings us one step closer to switch back to stable Rust vs using nightly.