### PR TITLE
stop taking an RNG as an argument for parse_pyreport and SqliteReportBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
+ "serde_json",
  "smallvec",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ testing = []
 include_dir = "0.7.3"
 memmap2 = "0.9.4"
 rand = "0.8.5"
-rusqlite = { version = "0.31.0", features = ["bundled", "limits"] }
+rusqlite = { version = "0.31.0", features = ["bundled", "limits", "serde_json"] }
 rusqlite_migration = { version = "1.2.0", features = ["from-directory"] }
 seahash = "4.1.0"
 serde = { version = "1.0.204", features = ["derive"] }

--- a/core/src/parsers/pyreport/mod.rs
+++ b/core/src/parsers/pyreport/mod.rs
@@ -40,32 +40,7 @@ pub fn parse_pyreport(
     chunks_file: &File,
     out_path: PathBuf,
 ) -> Result<SqliteReport> {
-    parse_pyreport_with_builder(
-        report_json_file,
-        chunks_file,
-        SqliteReportBuilder::new(out_path)?,
-    )
-}
-
-/// See [`parse_pyreport`]
-pub fn parse_pyreport_with_seed(
-    report_json_file: &File,
-    chunks_file: &File,
-    out_path: PathBuf,
-    seed: u64,
-) -> Result<SqliteReport> {
-    parse_pyreport_with_builder(
-        report_json_file,
-        chunks_file,
-        SqliteReportBuilder::new_with_seed(out_path, seed)?,
-    )
-}
-
-fn parse_pyreport_with_builder(
-    report_json_file: &File,
-    chunks_file: &File,
-    mut report_builder: SqliteReportBuilder,
-) -> Result<SqliteReport> {
+    let mut report_builder = SqliteReportBuilder::new(out_path)?;
     // Encapsulate all of this in a block so that `report_builder_tx` gets torn down
     // at the end. Otherwise, it'll hold onto a reference to `report_builder`
     // and prevent us from consuming `report_builder` to actually build a

--- a/core/src/report/sqlite/report.rs
+++ b/core/src/report/sqlite/report.rs
@@ -214,7 +214,7 @@ mod tests {
         let db_file_left = ctx.temp_dir.path().join("left.sqlite");
         let db_file_right = ctx.temp_dir.path().join("right.sqlite");
 
-        let mut left_report_builder = SqliteReportBuilder::new_with_seed(db_file_left, 5).unwrap();
+        let mut left_report_builder = SqliteReportBuilder::new(db_file_left).unwrap();
         let file_1 = left_report_builder.insert_file("src/report.rs").unwrap();
         let file_2 = left_report_builder
             .insert_file("src/report/models.rs")
@@ -262,8 +262,7 @@ mod tests {
             });
         }
 
-        let mut right_report_builder =
-            SqliteReportBuilder::new_with_seed(db_file_right, 10).unwrap();
+        let mut right_report_builder = SqliteReportBuilder::new(db_file_right).unwrap();
         let file_2 = right_report_builder
             .insert_file("src/report/models.rs")
             .unwrap();


### PR DESCRIPTION
i plumbed an RNG through all this in the first place to get a deterministic order for `RawUpload`s, which have random IDs, to write tests against. instead, in the tests where it matters, i skip `SqliteReportBuilder` and use the `Insertable` implementation directly with a hardcoded ID

speaking of, apparently rusqlite has serde_json support which solves the issue that made implementing `Insertable` for `RawUpload` difficult. so that's done

the motivation is to do a little bit of interface cleanup before exposing `parse_pyreport` to Python