### PR TITLE
disable non-security dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,12 @@ updates:
   - package-ecosystem: "pip"
     directory: "/" # pyproject.toml in root
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 0 # Security updates only
   - package-ecosystem: "cargo"
     directory: "/" # Cargo.toml workspace in root
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 0 # Security updates only


### PR DESCRIPTION
EDIT: also moved to weekly

8 open dependabot PRs felt like a bit of a nuisance. i'd like to do one of three things to rein it in, each having pros and cons:
- disable dependabot PRs for non-security updates (this PR)
  - pro: minimal overhead, minimal noise, minimal chance of regressions from dependency updates
  - con: misses improvements from minor version updates, and makes updating in the future a bigger chore
- run weekly instead so we can get into a routine of dealing with them all on monday
  - pro: less noisy
  - con: security updates happen less immediately
- telling dependabot to group all updates into a single PR
  - pro: less noisy
  - con: if a single update requires a code change (like `winnow` right now) you can't merge the rest of them

input welcome