### PR TITLE
use correct python version in maturin ci for aarch64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,12 @@
 #
 #    maturin generate-ci github --pytest
 #
-# Modified by hand to use PyPI's Trusted Publishing:
-# https://www.maturin.rs/distribution#using-pypis-trusted-publishing
-# Also to change when the workflow is triggered (should be on new release)
-# and remove unused target platforms.
+# Modified by hand to:
+# - use PyPI's Trusted Publishing https://www.maturin.rs/distribution#using-pypis-trusted-publishing
+# - trigger the workflow on new release
+# - add "packages: write" permission for uraimo/run-on-arch-action caching
+# - remove unnecessary target platforms
+# - make run-on-arch-action use deadsnakes Python 3.12
 name: CI
 
 on:
@@ -16,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   linux:
@@ -65,11 +68,18 @@ jobs:
           githubToken: ${{ github.token }}
           install: |
             apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip
-            pip3 install -U pip pytest
+            apt-get install -y gnupg ca-certificates
+            echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main" >> /etc/apt/sources.list.d/deadsnakes.list
+            apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
+            apt-get update
+            apt-get install -y --no-install-recommends python3.12 python3.12-venv python3-pip
+            python3.12 -m venv /venv
+            source /venv/bin/activate
+            pip install -U pip pytest
           run: |
             set -e
-            pip3 install codecov_rs --find-links dist --force-reinstall
+            source /venv/bin/activate
+            pip install codecov_rs --find-links dist --force-reinstall
             pytest
 
   musllinux:


### PR DESCRIPTION
tested in https://github.com/codecov/codecov-rs/pull/54
filed an issue in maturin about it https://github.com/PyO3/maturin/issues/2227

the publish workflow was generated with `maturin generate-ci github --pytest` so that `pytest` would be run for each platform. it worked fine for `x86_64` and `x86`, but for `aarch64` it failed with an error:
```
Looking in links: dist
  ERROR: Could not find a version that satisfies the requirement codecov_rs (from versions: none)
  ERROR: No matching distribution found for codecov_rs
```
([job link](https://github.com/codecov/codecov-rs/actions/runs/10949397825/job/30403888174))

the tl;dr is that `x86_64` and `x86` got to use the Python 3.12 version set up earlier in the workflow but `aarch64` had to use Python 3.10 because reasons. we set `requires-python = ">=3.12"` in `pyproject.toml` so when we tried to install our wheel on 3.10 it refused.

the fix here is to use the deadsnakes PPA to install a newer version of Python

alternatives:
- change `pyproject.toml` to require python >= 3.10 and make maturin build wheels for older versions
- stop running pytest
- stop building `aarch64`

we don't really need linux aarch64 support right now but it would be necessary to integrate codecov-rs in a cli or VS Code extension in the future