### PR TITLE
get maturin ci passing completely

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@
 # - add "packages: write" permission for uraimo/run-on-arch-action caching
 # - remove unnecessary target platforms
 # - make run-on-arch-action use deadsnakes Python 3.12
+# - hardcode maturin version v1.7.1 because of a bug
 name: CI
 
 on:
@@ -44,6 +45,7 @@ jobs:
           args: --release --out dist
           sccache: 'true'
           manylinux: auto
+          maturin-version: 'v1.7.1'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -105,6 +107,7 @@ jobs:
           args: --release --out dist
           sccache: 'true'
           manylinux: musllinux_1_2
+          maturin-version: 'v1.7.1'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -162,6 +165,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: 'true'
+          maturin-version: 'v1.7.1'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -198,6 +202,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: 'true'
+          maturin-version: 'v1.7.1'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/test_utils/fixtures/pyreport/.gitattributes
+++ b/test_utils/fixtures/pyreport/.gitattributes
@@ -1,0 +1,2 @@
+# Pyreports are only created on Codecov's Linux backend, no need for CRLF
+* text eol=lf


### PR DESCRIPTION
since the last release attempt, maturin `v1.7.2` came out which has a regression that impacts us. also i missed a windows issue (apparently my windows env doesn't have `autocrlf` enabled). this PR fixes both issues

i tested by adding a `pull_request` trigger which i've now removed. here's a run where everything passed https://github.com/codecov/codecov-rs/actions/runs/11041921939

a full recounting of release problems:
- [first release attempt](https://github.com/codecov/codecov-rs/actions/runs/10949397825/job/30403887267)
  - windows tempfile quirk, fixed in https://github.com/codecov/codecov-rs/pull/50
  - linux python version quirk, fixed in https://github.com/codecov/codecov-rs/pull/55
    - upstream maturin issue: pyo3/maturin/issues/2227
- [second release attempt](https://github.com/codecov/codecov-rs/actions/runs/11038099317/job/30660863361)
  - windows CRLF issue, fixed with `.gitattributes` (apparently my windows env didn't have this enabled)
  - musllinux missing libgcc_s.1.so issue, fixed by downgrading maturin
    - upstream maturin issue: PyO3/maturin/issues/2232