### PR TITLE
Optimize `save_report_lines` a bit

### DIFF
--- a/core/src/report/mod.rs
+++ b/core/src/report/mod.rs
@@ -63,9 +63,9 @@ pub trait ReportBuilder<R: Report> {
     /// passed-in models' `local_sample_id` fields are ignored and overwritten
     /// with values that are unique among all `CoverageSample`s with the same
     /// `raw_upload_id`.
-    fn multi_insert_coverage_sample(
+    fn multi_insert_coverage_sample<'a>(
         &mut self,
-        samples: Vec<&mut models::CoverageSample>,
+        samples: impl ExactSizeIterator<Item = &'a mut models::CoverageSample>,
     ) -> Result<()>;
 
     /// Create a [`models::BranchesData`] record and return it. The passed-in

--- a/core/src/report/sqlite/models.rs
+++ b/core/src/report/sqlite/models.rs
@@ -102,9 +102,11 @@ pub trait Insertable {
         Ok(())
     }
 
-    fn multi_insert<'a, I>(mut models: I, conn: &rusqlite::Connection) -> Result<()>
+    fn multi_insert<'a>(
+        mut models: impl ExactSizeIterator<Item = &'a Self>,
+        conn: &rusqlite::Connection,
+    ) -> Result<()>
     where
-        I: Iterator<Item = &'a Self> + ExactSizeIterator,
         Self: 'a,
     {
         let chunk_size = Self::maximum_chunk_size(conn);

--- a/core/src/test_utils/test_report.rs
+++ b/core/src/test_utils/test_report.rs
@@ -93,9 +93,9 @@ impl ReportBuilder<TestReport> for TestReportBuilder {
         Ok(sample)
     }
 
-    fn multi_insert_coverage_sample(
+    fn multi_insert_coverage_sample<'a>(
         &mut self,
-        samples: Vec<&mut CoverageSample>,
+        samples: impl ExactSizeIterator<Item = &'a mut CoverageSample>,
     ) -> error::Result<()> {
         self.report
             .samples


### PR DESCRIPTION
This avoids some intermediate allocations in particular for a `flag_map` case, as well as avoiding another allocation.

In other cases its unfortunately not possible to avoid more intermediate allocations.